### PR TITLE
カートに商品を追加するボタンの色が在庫の状況によって変化させるため #1

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -1362,6 +1362,20 @@ button.shopify-payment-button__button--unbranded {
   stroke: rgb(var(--color-button-text));
 }
 
+.button--green {
+  background-color: green;
+  color: white;
+}
+
+.button--green:hover {
+  background-color: blue;
+}
+
+.button--red {
+  background-color: red;
+  color: white;
+}
+
 /* Button - social share */
 
 .share-button {

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -77,12 +77,18 @@
             if product.selected_or_first_available_variant.quantity_rule.min > product.selected_or_first_available_variant.inventory_quantity and check_against_inventory
               assign quantity_rule_soldout = true
             endif
+            assign button_class = 'product-form__submit button button--full-width'
+            if quantity_rule_soldout == true
+              assign button_class = button_class | append: ' button--red'
+            else
+              assign button_class = button_class | append: ' button--green'
+            endif
           -%}
           <button
             id="ProductSubmitButton-{{ section_id }}"
             type="submit"
             name="add"
-            class="product-form__submit button button--full-width {% if show_dynamic_checkout %}button--secondary{% else %}button--primary{% endif %}"
+            class="{{ button_class }} {% if show_dynamic_checkout %}button--secondary{% else %}button--primary{% endif %}"
             {% if product.selected_or_first_available_variant.available == false
               or quantity_rule_soldout
               or product.selected_or_first_available_variant == nil


### PR DESCRIPTION
### PR Summary: 

- 商品詳細ページのカートに商品を追加するボタンの色を在庫の状況によって変化させる修正

### Why are these changes introduced?

- 以下の課題に対応するため
  - #1

### Other considerations

- quick addにおける商品を追加するボタンにおいては、未対応の状態です
- テストについては、一旦スルーしています
  - もし対応が必要な場合は教えてください

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

|  在庫がある場合  |  在庫がない場合  |
| ---- | ---- |
|  ![ 2024-07-18 8 25 46](https://github.com/user-attachments/assets/e2b21e94-b2d6-4116-873e-07255b5d9764) |  ![ 2024-07-18 8 17 38](https://github.com/user-attachments/assets/ef5fd91b-fc02-4ffb-9171-cb82e09624f0)  |

#### 在庫がある場合で、マウスをホバーさせた場合
https://github.com/user-attachments/assets/8ae40a67-ffe0-49d5-add3-44e215d40903

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://shinji-teststore.myshopify.com/)
