### PR TITLE
在庫の数によって商品追加ボタン下に表示するテキストを表示・変更できるようにするため #2

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -107,6 +107,7 @@
   "products": {
     "product": {
       "add_to_cart": "Add to cart",
+      "available": "Available!",
       "choose_options": "Choose options",
       "choose_product_options": "Choose options for {{ product_name }}",
       "description": "Description",
@@ -116,6 +117,7 @@
       "inventory_low_stock_show_count": "Low stock: {{ quantity }} left",
       "inventory_out_of_stock": "Out of stock",
       "inventory_out_of_stock_continue_selling": "In stock",
+      "low_stack": "Low stock",
       "sku": "SKU",
       "on_sale": "Sale",
       "product_variants": "Product variants",

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -107,6 +107,11 @@
             </span>
             {%- render 'loading-spinner' -%}
           </button>
+          {%- if product.selected_or_first_available_variant.inventory_quantity < 5 -%}
+            {{ 'products.product.low_stack' | t }}
+          {%- else -%}
+            {{ 'products.product.available' | t }}
+          {%- endif -%}
           {%- if show_dynamic_checkout -%}
             {{ form | payment_button }}
           {%- endif -%}


### PR DESCRIPTION
### PR Summary: 

- 在庫の数によって商品追加ボタン下に表示するテキストを表示・変更できるようにする修正

### Why are these changes introduced?

- 以下の課題に対応するため
  - #2 

### Other considerations

- quick addにおける商品を追加するボタンにおいては、未対応の状態です
- テストについては、一旦スルーしています
  - もし対応が必要な場合は教えてください

### Visual impact on existing themes
<!-- How will this visually affect merchants who upgrade to a new theme version with this change? -->

|  在庫が5個未満の場合  |  在庫が5個以上の場合  |
| ---- | ---- |
|  ![ 2024-07-18 9 25 57](https://github.com/user-attachments/assets/5eb1fdd6-f945-4543-9a2b-e9b672fe4a4f) | ![ 2024-07-18 9 22 44](https://github.com/user-attachments/assets/40e5a1d0-7ab3-4394-b42f-eb3ac80cd246) |

### Demo links
<!-- Please include a link to a demo store that includes preconfigured sections and settings to allow reviewers to easily test the features you are working on. -->

- [Store](https://shinji-teststore.myshopify.com/)