### PR TITLE
サイズなどの選択肢の下に、メタフィールドに設定した内容を表示するため #3

### DIFF
--- a/assets/component-product-variant-picker.css
+++ b/assets/component-product-variant-picker.css
@@ -150,3 +150,7 @@ variant-selects {
   }
 }
 /* End custom styles for Swatch display type */
+
+#size-description {
+  text-align: center;
+}

--- a/assets/product-variant-picker.js
+++ b/assets/product-variant-picker.js
@@ -1,0 +1,50 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const shirtS = document.getElementById('shirt-s');
+  const shirtM = document.getElementById('shirt-m');
+  const shirtL = document.getElementById('shirt-l');
+
+  if (!shirtS || !shirtM || !shirtL) {
+    return;
+  }
+
+  const sizeS = document.getElementById('shirt-s').getAttribute('data-value');
+  const sizeM = document.getElementById('shirt-m').getAttribute('data-value');
+  const sizeL = document.getElementById('shirt-l').getAttribute('data-value');
+
+  const sizeDescriptions = {
+    S: sizeS,
+    M: sizeM,
+    L: sizeL,
+  }
+
+  const sizeDescriptionDiv = document.getElementById('size-description');
+
+  function updateSizeDescription() {
+    const selectedSize = document.querySelector("input:checked[name*='size']").value;
+    sizeDescriptionDiv.textContent = sizeDescriptions[selectedSize];
+  }
+
+  function setupSizeChangeListener() {
+    const sizeSelects = document.querySelectorAll("input[name*='size']");
+    sizeSelects.forEach((sizeSelect) => {
+      sizeSelect.addEventListener('change', updateSizeDescription);
+    });
+  }
+
+  updateSizeDescription();
+
+  // 何かしらの操作でDOMツリーの更新があった場合は、文言をupdateする
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'childList' || mutation.type === 'attributes') {
+        setupSizeChangeListener();
+      }
+    });
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    attributes: true,
+    subtree: true,
+  });
+});

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -462,7 +462,17 @@
                 %}
 
               {%- when 'variant_picker' -%}
+                {% liquid
+                  assign size_s = product.metafields.custom.shirt_s
+                  assign size_m = product.metafields.custom.shirt_m
+                  assign size_l = product.metafields.custom.shirt_l
+                %}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
+                <div id="shirt-s" data-value="{{ size_s }}"></div>
+                <div id="shirt-m" data-value="{{ size_m }}"></div>
+                <div id="shirt-l" data-value="{{ size_l }}"></div>
+                <div id="size-description"></div>
+
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
                   block: block,
@@ -717,6 +727,7 @@
     <script type="application/ld+json">
       {{ product | structured_data }}
     </script>
+    <script src="{{ 'product-variant-picker.js' | asset_url }}" defer></script>
   </div>
 </product-info>
 


### PR DESCRIPTION
### PR Summary: 

- 商品のバリエーション選択の下に、メタフィールドに設定した内容を表示できるように修正

### Why are these changes introduced?

- 以下の課題に対応するため
  - #3

### Other considerations

- quick addにおける商品を追加するボタンにおいては、未対応の状態です
- テストについては、一旦スルーしています
  - もし対応が必要な場合は教えてください
- カートに追加のボタンの挙動が、バリエーションが追加されたことによって少し違和感のある挙動になっています
  - 商品のバリエーションによって、在庫数が異なるが、現状は全体の在庫の数に依存しているため、購入できない商品であっても、ボタンはアクティブな色となっている
  - 本タスクのスコープ外となるため、一旦スルーしています

#### DOMの変更の検知方法について

- 何かしらDOMの変更が検知されたら、文言をupdateするようにしています
- ちょっと無理やり感がある + もっと良い方法がありそうと思っていますので、良さそうな方法あれば教えていただきたいです🙇‍♂️

### Visual impact on existing themes

https://github.com/user-attachments/assets/0895a29a-3faa-48dc-a550-4c1d5698ba60

### Demo links

- [Store](https://shinji-teststore.myshopify.com/)